### PR TITLE
removing ws url remap from pure adaptor.

### DIFF
--- a/pure_adaptor/pure/v512/models.py
+++ b/pure_adaptor/pure/v512/models.py
@@ -1,31 +1,11 @@
 import os
-import urllib
 import logging
 from ..base import BasePureDataset
 
 logger = logging.getLogger(__name__)
 
 
-def ws_url_remap(pure_data_url):
-    """ Modifies a data location url to be http and /portal rather than /ws
-        Required for at least the test instance of the PURE API from
-        St. Andrews.
-        """
-    url_parts = list(urllib.parse.urlsplit(pure_data_url))
-    path_parts = [p for p in url_parts[2].split('/') if p]
-    url_parts[2] = '/'.join(['portal'] + path_parts[1:])
-    url_parts[0] = 'http'
-    return urllib.parse.urlunsplit(url_parts)
-
-
 class PureDataset(BasePureDataset):
 
     MAPPING_FILE_PATH = os.path.join(os.path.dirname(
         __file__), 'research_object_mapping.txt')
-
-    def _file_info(self, file_json):
-        """ Extracts the url and file name for a file.
-            """
-        file_name = file_json.get('title')
-        url = ws_url_remap(file_json.get('url'))
-        return url, file_name

--- a/pure_adaptor/pure/v59/models.py
+++ b/pure_adaptor/pure/v59/models.py
@@ -1,31 +1,11 @@
 import os
-import urllib
 import logging
 from ..base import BasePureDataset
 
 logger = logging.getLogger(__name__)
 
 
-def ws_url_remap(pure_data_url):
-    """ Modifies a data location url to be http and /portal rather than /ws
-        Required for at least the test instance of the PURE API from
-        St. Andrews.
-        """
-    url_parts = list(urllib.parse.urlsplit(pure_data_url))
-    path_parts = [p for p in url_parts[2].split('/') if p]
-    url_parts[2] = '/'.join(['portal'] + path_parts[1:])
-    url_parts[0] = 'http'
-    return urllib.parse.urlunsplit(url_parts)
-
-
 class PureDataset(BasePureDataset):
 
     MAPPING_FILE_PATH = os.path.join(os.path.dirname(
         __file__), 'research_object_mapping.txt')
-
-    def _file_info(self, file_json):
-        """ Extracts the url and file name for a file.
-            """
-        file_name = file_json.get('title')
-        url = ws_url_remap(file_json.get('url'))
-        return url, file_name

--- a/pure_adaptor/pure/v59/tests/test_models.py
+++ b/pure_adaptor/pure/v59/tests/test_models.py
@@ -5,7 +5,7 @@ import pytest
 import shutil
 import tempfile
 
-from ..models import PureDataset, ws_url_remap
+from ..models import PureDataset
 from pure_adaptor.pure.base import JMESCustomFunctions
 
 from rdsslib.taxonomy.taxonomy_client import TaxonomyGitClient
@@ -154,8 +154,7 @@ class TestPureDataset(object):
         assert self.pure_dataset.modified_date == self.now
 
     def test_files(self):
-        assert self.pure_dataset.files == [
-            (ws_url_remap(u), n) for u, n in self.url_name_pairs]
+        assert self.pure_dataset.files == self.url_name_pairs
 
     def test_original_metadata(self):
         assert self.pure_dataset.original_metadata == self.mock_dataset
@@ -171,9 +170,3 @@ class TestPureDataset(object):
 
     def teardown(self):
         pass
-
-
-def test_ws_url_remap():
-    url = 'https://pure_endpoint_url.ac.uk/ws/files/an_id/test_file.pdf'
-    url_map = 'http://pure_endpoint_url.ac.uk/portal/files/an_id/test_file.pdf'
-    assert ws_url_remap(url) == url_map

--- a/pure_adaptor/tests/test_pure_adaptor.py
+++ b/pure_adaptor/tests/test_pure_adaptor.py
@@ -107,7 +107,7 @@ def test_uuids_added_to_data():
     })
 
     with patch.dict(os.environ, **env), requests_mock.mock() as m:
-        m.get('http://riswebtest.st-andrews.ac.uk/portal/'
+        m.get('https://riswebtest.st-andrews.ac.uk/ws/'
               'files/241900740/Supporting_Data.zip', text='')
         m.get('http://somewhere.over/the/rainbow/datasets', text=response)
         m.head('http://somewhere.over/the/rainbow/datasets')


### PR DESCRIPTION
This PR removes a the url remapping of file locations from the Pure API output that was initially introduced to deal with a quirk of St. Andrews test Pure environment. This is now causing issues with the UAT deployment of the adaptor which is targeting the prod instance Pure that doesn't require this remapping, which is assumed to be the case with all future Pure Adaptor deployments. 